### PR TITLE
Fix issue in anthropic chat when khoj message becomes top message

### DIFF
--- a/src/khoj/processor/conversation/anthropic/anthropic_chat.py
+++ b/src/khoj/processor/conversation/anthropic/anthropic_chat.py
@@ -180,6 +180,10 @@ def converse_anthropic(
         tokenizer_name=tokenizer_name,
     )
 
+    if len(messages) > 1:
+        if messages[0].role == "assistant":
+            messages = messages[1:]
+
     for message in messages.copy():
         if message.role == "system":
             system_prompt += message.content


### PR DESCRIPTION
This is because Anthropic requires the first message in the chat history to be from the user.